### PR TITLE
Fixes to promotions in checkout view

### DIFF
--- a/screen/store/components/ApiServices.js
+++ b/screen/store/components/ApiServices.js
@@ -105,6 +105,7 @@ var ProductService = {
         return axios.post("/rest/s1/pop/cart/promoCode",data,headers).then(function (response) { return response.data; });
     },
     deletePromoCode: function(data, headers) {
-        return axios.delete("/rest/s1/pop/cart/promoCode",data,headers).then(function (response) { return response.data; });
+        return axios.delete("/rest/s1/pop/cart/promoCode", {data: data, headers: headers})
+            .then(function (response) { return response.data; });
     }
 };

--- a/screen/store/components/ComponentsCheckout.js
+++ b/screen/store/components/ComponentsCheckout.js
@@ -168,6 +168,8 @@ storeComps.CheckOutPage = {
                 }
 
                 this.productsInCart = data;
+                // Notify vue of property change
+                this.$set(this.productsInCart, 'orderItemList', this.productsInCart.orderItemList);
                 this.setShippingItemPrice();
                 this.afterDelete();
             }.bind(this));
@@ -248,10 +250,12 @@ storeComps.CheckOutPage = {
         applyPromotionCode: function() {
             var dataCode = {promoCode: this.promoCode, orderId: this.productsInCart.orderHeader.orderId};
             ProductService.addPromoCode(dataCode,this.axiosConfig).then(function (data) {
-                if(data.messages.includes("not valid")) {
+                if(data.messages && data.messages.includes("not valid")) {
                     this.promoError = data.messages;
                 } else {
                     this.promoSuccess = data.messages;
+                    this.getCartInfo();
+                    this.promoCode = "";
                 }
             }.bind(this));
         },

--- a/screen/store/components/ComponentsCheckout.js
+++ b/screen/store/components/ComponentsCheckout.js
@@ -293,7 +293,7 @@ storeComps.CheckOutPage = {
         },
         deleteOrderProduct: function(item) {
             ProductService.deleteOrderProduct(item.orderId, item.orderItemSeqId, this.axiosConfig)
-                .then(function (data) { this.getCartInfo(); }.bind(this));
+                .then(function (data) { this.getCartInfo(); this.getCartShippingOptions(); }.bind(this));
         },
         deleteOrderPromo: function(item) {
             ProductService.deletePromoCode({orderId: item.orderId, promoCodeId: item.promoCodeId}, this.axiosConfig.headers)

--- a/screen/store/components/ComponentsCheckout.js
+++ b/screen/store/components/ComponentsCheckout.js
@@ -295,6 +295,10 @@ storeComps.CheckOutPage = {
             ProductService.deleteOrderProduct(item.orderId, item.orderItemSeqId, this.axiosConfig)
                 .then(function (data) { this.getCartInfo(); }.bind(this));
         },
+        deleteOrderPromo: function(item) {
+            ProductService.deletePromoCode({orderId: item.orderId, promoCodeId: item.promoCodeId}, this.axiosConfig.headers)
+                .then(function (data) { this.getCartInfo(); }.bind(this));
+        },
         selectBillingAddress: function(address) {
             this.paymentMethod.address1 = address.postalAddress.address1;
             this.paymentMethod.address2 = address.postalAddress.address2;

--- a/screen/store/components/ComponentsCheckout.js
+++ b/screen/store/components/ComponentsCheckout.js
@@ -295,10 +295,10 @@ storeComps.CheckOutPage = {
             ProductService.deleteOrderProduct(item.orderId, item.orderItemSeqId, this.axiosConfig)
                 .then(function (data) { this.getCartInfo(); this.getCartShippingOptions(); }.bind(this));
         },
-        deleteOrderPromo: function(item) {
-            ProductService.deletePromoCode({orderId: item.orderId, promoCodeId: item.promoCodeId}, this.axiosConfig.headers)
-                .then(function (data) { this.getCartInfo(); }.bind(this));
-        },
+        // deleteOrderPromo: function(item) {
+        //     ProductService.deletePromoCode({orderId: item.orderId, promoCodeId: item.promoCodeId}, this.axiosConfig.headers)
+        //         .then(function (data) { this.getCartInfo(); }.bind(this));
+        // },
         selectBillingAddress: function(address) {
             this.paymentMethod.address1 = address.postalAddress.address1;
             this.paymentMethod.address2 = address.postalAddress.address2;

--- a/screen/store/components/ComponentsCheckout.js
+++ b/screen/store/components/ComponentsCheckout.js
@@ -295,10 +295,6 @@ storeComps.CheckOutPage = {
             ProductService.deleteOrderProduct(item.orderId, item.orderItemSeqId, this.axiosConfig)
                 .then(function (data) { this.getCartInfo(); this.getCartShippingOptions(); }.bind(this));
         },
-        // deleteOrderPromo: function(item) {
-        //     ProductService.deletePromoCode({orderId: item.orderId, promoCodeId: item.promoCodeId}, this.axiosConfig.headers)
-        //         .then(function (data) { this.getCartInfo(); }.bind(this));
-        // },
         selectBillingAddress: function(address) {
             this.paymentMethod.address1 = address.postalAddress.address1;
             this.paymentMethod.address2 = address.postalAddress.address2;

--- a/screen/store/components/template/CheckoutPage.html
+++ b/screen/store/components/template/CheckoutPage.html
@@ -38,9 +38,6 @@
                         <div v-if="item.itemTypeEnumId=='ItemProduct'" class="item-actions pr-4" @click="deleteOrderProduct(item)">
                             <span>Delete</span>
                         </div>
-<!--                        <div v-if="item.itemTypeEnumId=='ItemDiscount'" class="item-actions pr-4" @click="deleteOrderPromo(item)">-->
-<!--                            <span>Delete</span>-->
-<!--                        </div>-->
                     </div>
                 </div>
 

--- a/screen/store/components/template/CheckoutPage.html
+++ b/screen/store/components/template/CheckoutPage.html
@@ -35,7 +35,10 @@
                     </div>
                     <div class="col col-3 col-sm-3 text-right">
                         <div class="place-order-total pr-4">${{item.unitAmount.toFixed(2)}}</div>
-                        <div class="item-actions pr-4" @click="deleteOrderProduct(item)" v-if="item.itemTypeEnumId=='ItemProduct'">
+                        <div v-if="item.itemTypeEnumId=='ItemProduct'" class="item-actions pr-4" @click="deleteOrderProduct(item)">
+                            <span>Delete</span>
+                        </div>
+                        <div v-if="item.itemTypeEnumId=='ItemDiscount'" class="item-actions pr-4" @click="deleteOrderPromo(item)">
                             <span>Delete</span>
                         </div>
                     </div>

--- a/screen/store/components/template/CheckoutPage.html
+++ b/screen/store/components/template/CheckoutPage.html
@@ -38,9 +38,9 @@
                         <div v-if="item.itemTypeEnumId=='ItemProduct'" class="item-actions pr-4" @click="deleteOrderProduct(item)">
                             <span>Delete</span>
                         </div>
-                        <div v-if="item.itemTypeEnumId=='ItemDiscount'" class="item-actions pr-4" @click="deleteOrderPromo(item)">
-                            <span>Delete</span>
-                        </div>
+<!--                        <div v-if="item.itemTypeEnumId=='ItemDiscount'" class="item-actions pr-4" @click="deleteOrderPromo(item)">-->
+<!--                            <span>Delete</span>-->
+<!--                        </div>-->
                     </div>
                 </div>
 


### PR DESCRIPTION
This pull request addresses two issues with promotion codes. Firstly, added promotion codes were not reflected on the cart upon clicking the 'Apply' button as Vue was not detecting the object mutation. Secondly, there was no way to delete applied promotion codes from the checkout cart. Deleting codes is desirable since the customer may have more than one code and they might want to try both of them. There was already a service for deleting a promotion code from an order exposed via REST, however the axios call was not implemented correctly.