### PR TITLE
Checkout cart promotion feedback and deletion

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -41,6 +41,7 @@ Written in 2018 by Arlen McDonell - jmcdl
 Written in 2019 by Jovanny Castaño - isokmio
 Written in 2019 by Sergio Loaiza - serloap
 Written in 2019 by Alex Bravo - alexbravotsoft
+Written in 2020 by Lombardo Paredes - lombardo2
 
 
 ===========================================================================
@@ -70,3 +71,4 @@ Written in 2018 by Arlen McDonell - jmcdl
 Written in 2019 by Jovanny Castaño - isokmio
 Written in 2019 by Sergio Loaiza - serloap
 Written in 2019 by Alex Bravo - alexbravotsoft
+Written in 2020 by Lombardo Paredes - lombardo2

--- a/screen/store/components/ComponentsCheckout.js
+++ b/screen/store/components/ComponentsCheckout.js
@@ -422,7 +422,9 @@ storeComps.CheckOutPage = {
     components: { "product-image": storeComps.ProductImageTemplate },
     mounted: function() {
         this.loading = true;
-
+        $(function () {
+            $('[data-toggle="popover"]').popover()
+        })
         if (this.$root.apiKey == null) {
             localStorage.redirect = 'checkout';
             this.$router.push({ name: 'login'});

--- a/screen/store/components/ComponentsCheckout.js
+++ b/screen/store/components/ComponentsCheckout.js
@@ -60,7 +60,7 @@ storeComps.CheckOutPage = {
             countriesList: [], regionsList: [], shippingOption: "", addressOption: "", paymentOption: "", isSameAddress: "0", shippingItemPrice: 0,
             isUpdate: false, isSpinner: false, responseMessage: "", toNameErrorMessage: "", countryErrorMessage: "", addressErrorMessage: "", 
             cityErrorMessage: "", stateErrorMessage: "", postalCodeErrorMessage: "", contactNumberErrorMessage: "", paymentId: 0, 
-            freeShipping:false, promoSuccess: "", loading: false,
+            freeShipping:false, promoSuccess: "", loading: false, mouseInPopover: false,
             listShippingOptions: [],  axiosConfig: { headers: { "Content-Type": "application/json;charset=UTF-8", "Access-Control-Allow-Origin": "*",
             "api_key":this.$root.apiKey, "moquiSessionToken":this.$root.moquiSessionToken } }
         };
@@ -70,21 +70,36 @@ storeComps.CheckOutPage = {
             return this.shippingMethod && this.shippingMethod.shippingTotal != undefined ? Number(this.shippingMethod.shippingTotal) : this.shippingItemPrice;
         },
         promoDiscount: function () {
-            return this.productsInCart.orderItemList ?
-                this.productsInCart.orderItemList.reduce(function (acc, curr) {
-                    var value = curr.itemTypeEnumId == 'ItemDiscount' ? curr.unitAmount * curr.quantity : 0;
-                    return acc + value
-                }, 0) : 0
+            return this.productsInCart.orderItemList ? this.getCartValueByItemEnum('ItemDiscount') : 0;
         },
         productTotal: function () {
+            return this.productsInCart.orderItemList ? this.getCartValueByItemEnum('ItemProduct') : 0;
+        },
+        //TODO Getting the applied promo codes should be done server-side
+        appliedPromoCodes: function () {
             return this.productsInCart.orderItemList ?
-                this.productsInCart.orderItemList.reduce(function (acc, curr) {
-                    var value = curr.itemTypeEnumId == 'ItemProduct' ? curr.unitAmount * curr.quantity : 0;
-                    return acc + value
-                }, 0) : 0
+                this.getUniqueValuesByProperty(this.productsInCart.orderItemList, 'promoCodeText',
+                    function (v) {
+                        return v.itemTypeEnumId == 'ItemDiscount'
+                    })
+                : [];
         }
     },
     methods: {
+        getUniqueValuesByProperty: function (items, property, filter){
+            var uniqueVals = {};
+            items.forEach(function (val) {
+                if(filter(val) && !(val[property] in uniqueVals))
+                    uniqueVals[val[property]] = true;
+            });
+            return Object.getOwnPropertyNames(uniqueVals);
+        },
+        getCartValueByItemEnum: function(itemEnum) {
+            return this.productsInCart.orderItemList.reduce(function (a, c) {
+                var value = c.itemTypeEnumId == itemEnum ? c.unitAmount * c.quantity : 0;
+                return a + value;
+            }, 0);
+        },
         notAddressSeleted: function() {
             return (this.addressOption == null || this.addressOption == ''
                 || this.listShippingAddress == null || this.listShippingAddress.length == 0);
@@ -287,7 +302,7 @@ storeComps.CheckOutPage = {
             this.loading = true;
             var data = { "orderId": item.orderId, "orderItemSeqId": item.orderItemSeqId, "quantity": item.quantity };
             ProductService.updateProductQuantity(data, this.axiosConfig)
-                .then(function (data) { 
+                .then(function (data) {
                     this.getCartInfo();
                     this.getCartShippingOptions();
                 }.bind(this));
@@ -308,6 +323,13 @@ storeComps.CheckOutPage = {
         deleteOrderProduct: function(item) {
             ProductService.deleteOrderProduct(item.orderId, item.orderItemSeqId, this.axiosConfig)
                 .then(function (data) { this.getCartInfo(); this.getCartShippingOptions(); }.bind(this));
+        },
+        deletePromoCode: function(promo) {
+            var promoInfo = this.productsInCart.orderPromoCodeDetailList.find(function (val) {
+                return val.promoCode == promo;
+            });
+            ProductService.deletePromoCode({orderId: promoInfo.orderId, promoCodeId: promoInfo.promoCodeId},
+                this.axiosConfig.headers).then(function (data) { this.getCartInfo(); this.getCartShippingOptions(); }.bind(this));
         },
         selectBillingAddress: function(address) {
             this.paymentMethod.address1 = address.postalAddress.address1;
@@ -362,7 +384,6 @@ storeComps.CheckOutPage = {
         cleanShippingAddress: function() { this.shippingAddress = {}; this.isUpdate = false; },
         cleanPaymentMethod: function() { this.paymentMethod = {}; this.isUpdate = false; },
         resetData: function(){
-            $("#modal-card-content").trigger('reset');
             this.paymentMethod = {};
             this.shippingAddress = {};
             this.isUpdate = false;
@@ -371,6 +392,32 @@ storeComps.CheckOutPage = {
         clearCvv: function () {
             this.cvv = "";
         },
+        showPopover: function (elementId, popoverId) {
+            var element = $("#"+elementId).first();
+            var popover = $("#"+popoverId).first();
+            var pop = new Popper(element, popover, {
+                placement: "top",
+                modifiers: {
+                    flip: { behavior: [] },
+                    offset: { enabled: true, offset: '5,2' },
+                    arrow: { element: '.arrow' }
+                }
+            });
+            popover.addClass("show");
+        },
+        hidePopover: function (popoverId, source) {
+            //If user leaves the popover parent element without entering the popover, close it.
+            if(source == 'element') {
+                //We need to allow time for the user to enter the popover
+                setTimeout(function() {
+                    if(!this.mouseInPopover)
+                    $("#"+popoverId).first().removeClass("show");
+                }.bind(this), 250);
+            } else {
+                $("#"+popoverId).first().removeClass("show");
+                this.mouseInPopover = false;
+            }
+        }
     },
     components: { "product-image": storeComps.ProductImageTemplate },
     mounted: function() {
@@ -387,7 +434,7 @@ storeComps.CheckOutPage = {
             this.getCartShippingOptions();
             this.getCustomerShippingAddresses();
             this.getCustomerPaymentMethods();
-            this.getRegions('USA');  
+            this.getRegions('USA');
         }
     }
 };

--- a/screen/store/components/ComponentsCheckout.js
+++ b/screen/store/components/ComponentsCheckout.js
@@ -89,7 +89,7 @@ storeComps.CheckOutPage = {
         getUniqueValuesByProperty: function (items, property, filter){
             var uniqueVals = {};
             items.forEach(function (val) {
-                if(filter(val) && !(val[property] in uniqueVals))
+                if(filter(val) && !(val[property] in uniqueVals) && val[property] != undefined)
                     uniqueVals[val[property]] = true;
             });
             return Object.getOwnPropertyNames(uniqueVals);

--- a/screen/store/components/ComponentsCheckout.js
+++ b/screen/store/components/ComponentsCheckout.js
@@ -69,6 +69,20 @@ storeComps.CheckOutPage = {
         shippingPrice: function () {
             return this.shippingMethod && this.shippingMethod.shippingTotal != undefined ? Number(this.shippingMethod.shippingTotal) : this.shippingItemPrice;
         },
+        promoDiscount: function () {
+            return this.productsInCart.orderItemList ?
+                this.productsInCart.orderItemList.reduce(function (acc, curr) {
+                    var value = curr.itemTypeEnumId == 'ItemDiscount' ? curr.unitAmount * curr.quantity : 0;
+                    return acc + value
+                }, 0) : 0
+        },
+        productTotal: function () {
+            return this.productsInCart.orderItemList ?
+                this.productsInCart.orderItemList.reduce(function (acc, curr) {
+                    var value = curr.itemTypeEnumId == 'ItemProduct' ? curr.unitAmount * curr.quantity : 0;
+                    return acc + value
+                }, 0) : 0
+        }
     },
     methods: {
         notAddressSeleted: function() {

--- a/screen/store/components/ComponentsCheckout.js
+++ b/screen/store/components/ComponentsCheckout.js
@@ -422,9 +422,6 @@ storeComps.CheckOutPage = {
     components: { "product-image": storeComps.ProductImageTemplate },
     mounted: function() {
         this.loading = true;
-        $(function () {
-            $('[data-toggle="popover"]').popover()
-        })
         if (this.$root.apiKey == null) {
             localStorage.redirect = 'checkout';
             this.$router.push({ name: 'login'});

--- a/screen/store/components/template/CheckoutPage.html
+++ b/screen/store/components/template/CheckoutPage.html
@@ -44,7 +44,7 @@
                 <hr>
                 <div class="row div-total">
                     <span class="col col-9 col-lg-9">Products</span>
-                    <span class="col col-3 col-lg-3 text-right" v-if="productsInCart.orderPart">
+                    <span class="col col-3 col-lg-3 text-right place-order-total" v-if="productsInCart.orderPart">
                         <span class="pr-4">${{productTotal.toFixed(2)}}</span>
                     </span>
                 </div>

--- a/screen/store/components/template/CheckoutPage.html
+++ b/screen/store/components/template/CheckoutPage.html
@@ -50,9 +50,24 @@
                 </div>
                 <hr>
 
-                <hr>
-                <div class="row div-total">
-                    <span class="col col-9 col-lg-9">Promotions</span>
+                <div class="popover fade bs-popover-top p-2" id="popup"
+                     @mouseleave="hidePopover('popup', 'popover')" @mouseenter="mouseInPopover = true">
+                    <div class="row" v-for="promo in appliedPromoCodes">
+                        <div class="col pr-1">{{promo}}</div>
+                        <div class="col pl-1">
+                            <i class="fa fa-times-circle" @click="deletePromoCode(promo)"></i>
+                        </div>
+                    </div>
+                    <div class="arrow"></div>
+                </div>
+
+                <hr v-show="promoDiscount < 0">
+                <div class="row div-total" v-show="promoDiscount < 0">
+                    <span class="col col-9 col-lg-9">
+                        Promotions
+                        <i id="promoInfo" class="fa fa-info-circle" @mouseenter="showPopover('promoInfo','popup')"
+                        @mouseleave="hidePopover('popup','element')"></i>
+                    </span>
                     <span class="col col-3 col-lg-3 text-right place-order-total">
                         <span class="pr-4">${{promoDiscount.toFixed(2)}}</span>
                     </span>

--- a/screen/store/components/template/CheckoutPage.html
+++ b/screen/store/components/template/CheckoutPage.html
@@ -61,7 +61,7 @@
                     <div class="row" v-for="promo in appliedPromoCodes">
                         <div class="col pr-1">{{promo}}</div>
                         <div class="col pl-1">
-                            <i class="fa fa-times-circle" @click="deletePromoCode(promo)"></i>
+                            <i class="fa fa-trash-alt" @click="deletePromoCode(promo)"></i>
                         </div>
                     </div>
                     <div class="arrow"></div>
@@ -72,7 +72,7 @@
                     <span class="col col-9 col-lg-9">
                         Promotions
                         <i id="promoInfo" class="fa fa-info-circle" @mouseenter="showPopover('promoInfo','popup')"
-                        @mouseleave="hidePopover('popup','element')"></i>
+                        @mouseleave="hidePopover('popup','element')" style="cursor: pointer"></i>
                     </span>
                     <span class="col col-3 col-lg-3 text-right place-order-total">
                         <span class="pr-4">${{promoDiscount.toFixed(2)}}</span>

--- a/screen/store/components/template/CheckoutPage.html
+++ b/screen/store/components/template/CheckoutPage.html
@@ -43,12 +43,20 @@
 
                 <hr>
                 <div class="row div-total">
-                    <span class="col col-9 col-lg-9">Subtotal</span>
+                    <span class="col col-9 col-lg-9">Products</span>
                     <span class="col col-3 col-lg-3 text-right" v-if="productsInCart.orderPart">
-                        <span class="pr-4">${{(productsInCart.orderPart.partTotal - shippingPrice).toFixed(2)}}</span>
+                        <span class="pr-4">${{productTotal.toFixed(2)}}</span>
                     </span>
                 </div>
                 <hr>
+
+                <hr>
+                <div class="row div-total">
+                    <span class="col col-9 col-lg-9">Promotions</span>
+                    <span class="col col-3 col-lg-3 text-right place-order-total">
+                        <span class="pr-4">${{promoDiscount.toFixed(2)}}</span>
+                    </span>
+                </div>
 
                 <div class="row div-total">
                     <span class="col col-9 col-lg-9 mt-4">Shipping</span>
@@ -59,7 +67,7 @@
                     </span>
                     <hr style="width: 96%;">
                     <span class="col col-9 col-lg-9 mt-3 mb-5">Total</span>
-                    <span class="col col-3 col-lg-3 mt-3 text-right place-order-total" v-if="productsInCart.orderHeader">
+                    <span class="col col-3 col-lg-3 mt-3 text-right" v-if="productsInCart.orderHeader">
                         <span class="pr-4">${{productsInCart.orderHeader.grandTotal.toFixed(2)}}</span>
                     </span>
                 </div>

--- a/screen/store/components/template/CheckoutPage.html
+++ b/screen/store/components/template/CheckoutPage.html
@@ -15,7 +15,7 @@
                     <span class="col col-3 col-sm-3 text-center">Price</span>
                 </p>
                 <hr class="hr">
-                <div class="row" v-for="item in productsInCart.orderItemList" :key="item.itemTypeEnumId + '' + item.productId" v-if="item.itemTypeEnumId != 'ItemShipping'">
+                <div class="row" v-for="(item, i) in productsInCart.orderItemList" :key="item.itemTypeEnumId + '' + item.productId" v-if="item.itemTypeEnumId != 'ItemShipping'">
                     <div class="col col-sm-2 d-none d-sm-block">
                         <product-image :productId="item.productId" v-if="item.itemTypeEnumId=='ItemProduct'"
                            class="mb-1"/>
@@ -29,7 +29,8 @@
                             <span class="place-order-total"> Save ${{(item.unitListPrice - item.unitAmount).toFixed(2)}}</span>
                         </p>
                     </div>
-                    <div class="col col-3 col-sm-2">
+                    <div class="col col-3 col-sm-2"
+                         :class="{'mb-3': item.itemTypeEnumId != 'ItemProduct' && i != productsInCart.orderItemList.length-1}">
                         <input class="input-quantity form-control" id="quantity" @change="updateProductQuantity(item)"
                             type="text" v-model="item.quantity" :disabled="item.itemTypeEnumId != 'ItemProduct'" />
                     </div>

--- a/screen/store/components/template/CheckoutPage.html
+++ b/screen/store/components/template/CheckoutPage.html
@@ -22,20 +22,25 @@
                     </div>
                     <div class="col col-6 col-sm-5">
                         <p class="item-text-desc">
-                            <a class="item-text-desc" :href="'product/' + item.productId">{{item.itemDescription}}</a>
+                            <a class="item-text-desc" :href="'product/' + item.productId" v-if="item.itemTypeEnumId == 'ItemProduct'">
+                                {{item.itemDescription}}
+                            </a>
+                            <a class="item-text-desc" v-else>
+                                {{item.promoCodeText}}
+                            </a>
                         </p>
                         <p v-if="item.unitListPrice && ((item.unitListPrice - item.unitAmount) != 0)" class="last-price">
                             <del>${{item.unitListPrice}}</del>
                             <span class="place-order-total"> Save ${{(item.unitListPrice - item.unitAmount).toFixed(2)}}</span>
                         </p>
                     </div>
-                    <div class="col col-3 col-sm-2"
-                         :class="{'mb-3': item.itemTypeEnumId != 'ItemProduct' && i != productsInCart.orderItemList.length-1}">
+                    <div class="col col-3 col-sm-2">
                         <input class="input-quantity form-control" id="quantity" @change="updateProductQuantity(item)"
-                            type="text" v-model="item.quantity" :disabled="item.itemTypeEnumId != 'ItemProduct'" />
+                            type="text" v-model="item.quantity" v-show="item.itemTypeEnumId == 'ItemProduct'"/>
                     </div>
                     <div class="col col-3 col-sm-3 text-right">
-                        <div class="place-order-total pr-4">${{item.unitAmount.toFixed(2)}}</div>
+                        <div class="place-order-total pr-4" v-if="item.itemTypeEnumId == 'ItemProduct'">${{item.unitAmount.toFixed(2)}}</div>
+                        <div class="place-order-total pr-4" v-else>${{(item.quantity*item.unitAmount).toFixed(2)}}</div>
                         <div v-if="item.itemTypeEnumId=='ItemProduct'" class="item-actions pr-4" @click="deleteOrderProduct(item)">
                             <span>Delete</span>
                         </div>

--- a/screen/store/components/template/CheckoutPage.html
+++ b/screen/store/components/template/CheckoutPage.html
@@ -26,7 +26,7 @@
                                 {{item.itemDescription}}
                             </a>
                             <a class="item-text-desc" v-else>
-                                {{item.promoCodeText}}
+                                {{item.promoCodeText ? item.promoCodeText : item.itemDescription}}
                             </a>
                         </p>
                         <p v-if="item.unitListPrice && ((item.unitListPrice - item.unitAmount) != 0)" class="last-price">
@@ -61,7 +61,7 @@
                     <div class="row" v-for="promo in appliedPromoCodes">
                         <div class="col pr-1">{{promo}}</div>
                         <div class="col pl-1">
-                            <i class="fa fa-trash-alt" @click="deletePromoCode(promo)"></i>
+                            <i class="fa fa-trash-alt pointer" @click="deletePromoCode(promo)"></i>
                         </div>
                     </div>
                     <div class="arrow"></div>
@@ -71,8 +71,8 @@
                 <div class="row div-total" v-show="promoDiscount < 0">
                     <span class="col col-9 col-lg-9">
                         Promotions
-                        <i id="promoInfo" class="fa fa-info-circle" @mouseenter="showPopover('promoInfo','popup')"
-                        @mouseleave="hidePopover('popup','element')" style="cursor: pointer"></i>
+                        <i id="promoInfo" class="fa fa-info-circle pointer" @mouseenter="showPopover('promoInfo','popup')" v-show="appliedPromoCodes.length>0"
+                        @mouseleave="hidePopover('popup','element')"></i>
                     </span>
                     <span class="col col-3 col-lg-3 text-right place-order-total">
                         <span class="pr-4">${{promoDiscount.toFixed(2)}}</span>

--- a/screen/store/d.xml
+++ b/screen/store/d.xml
@@ -75,8 +75,8 @@ along with this software (see the LICENSE.md file). If not, see
     <script src="https://cdnjs.cloudflare.com/ajax/libs/vue-router/3.0.1/vue-router.min.js" integrity="sha256-yEB9jUlD51i5kxJZlzgzfR6XmVKI76Nl1WRA1aqIilU=" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/axios/0.18.0/axios.min.js" integrity="sha256-mpnrJ5DpEZZkwkE1ZgkEQQJW/46CSEh/STrZKOB/qoM=" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.22.2/moment.min.js" integrity="sha256-CutOzxCRucUsn6C6TcEYsauvvYilEniTXldPa6/wu0k=" crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.js" integrity="sha256-p7N78jBS61kk2Z9gzOF1nUCvhUvrLeTdCNZat+go6qE="></script>
+    <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js" integrity="sha256-KUNqRLl+PMcaXFAnrXXATFOkGtC99NSTklZi185m37s="></script>
 
     <script src="/store/config.js"></script>
     <script src="/store/components/combined.min.js"></script>

--- a/template/store/root.html.ftl
+++ b/template/store/root.html.ftl
@@ -15,6 +15,7 @@
     </div>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.16.1/umd/popper.min.js" integrity="sha256-/ijcOLwFf26xEYAjW75FizKVo5tnTYiQddPZoLUHHZ8=" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.1.2/js/bootstrap.min.js" integrity="sha256-IeI0loa35pfuDxqZbGhQUiZmD2Cywv1/bdqiypGW46o=" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/mouse0270-bootstrap-notify/3.1.7/bootstrap-notify.min.js" integrity="sha256-LlN0a0J3hMkDLO1mhcMwy+GIMbIRV7kvKHx4oCxNoxI=" crossorigin="anonymous"></script>
 <script>


### PR DESCRIPTION
User visible changes:
1. The ‘Subtotal’ price is broken up in two categories: Products and Promotions. Products shows the total price of the products and Promotions the amount discounted due to promotions. This is done so the user has clear indication on how much the promotion is saving them.
2. Promotions in the cart are described using the promo code instead of the promotion title, as commented on the code base, I'm not totally sure if this change is in order. The promotion quantity is hidden, as from a user perspective it really little sense, showing instead the total amount saved per item.
3. If there is a promo code applied in the cart, an info icon is shown next to the promotion category, hovering over it shows the currently applied promo codes and a way to delete them from the order.

Code changes and implications:
1. The total price per product and promotion is calculated iterating and accumulating over the products in cart. Ideally this should be done server side but as the cart is small in size and the grand total is still calculated in the server, I don’t think this is much of an issue.
2. The code now depends on popper.js. Some bootstrap components also depend on it, so I found it weird it was not already included. The library itself weights 4KB so I don’t see much issue including it.
3.  There is no server-side way for obtaining the *applied* promo codes, as a cart can have promo codes which can’t be applied, and not affecting its price. I processed them client-side, following 1. logic of the cart being small. A service for obtaining applied codes might be desirable though.
The performance impact of the code changes seems to be negligible

Checkout with promotions before changes:
<img width="400" alt="Captura de Pantalla 2020-02-12 a la(s) 6 13 32 p  m" src="https://user-images.githubusercontent.com/3332569/74386668-8fd12a80-4dc4-11ea-9c48-119e02977d63.png">

After changes:
<img width="400" alt="Captura de Pantalla 2020-02-12 a la(s) 6 24 57 p  m" src="https://user-images.githubusercontent.com/3332569/74386836-ffdfb080-4dc4-11ea-8d67-2b59ba8b3481.png">

Note that the promotion code was limited to 5 items per configuration.