### PR TITLE
Custom store messages in checkout page

### DIFF
--- a/data/PopRestStoreAaaSetupData.xml
+++ b/data/PopRestStoreAaaSetupData.xml
@@ -38,7 +38,7 @@ along with this software (see the LICENSE.md file). If not, see
     <moqui.basic.Enumeration enumCode="template_client_orderHistory" description="Template Client Order History" enumId="PsstTemplateClientOrderHistory" enumTypeId="ProductStoreSettingType"/>
     <moqui.basic.Enumeration enumCode="template_client_productImage" description="Template Client Product Image" enumId="PsstTemplateClientProductImage" enumTypeId="ProductStoreSettingType"/>
     <moqui.basic.Enumeration enumCode="template_client_resetPassword" description="Template Client Reset Password" enumId="PsstTemplateClientResetPassword" enumTypeId="ProductStoreSettingType"/>
-    <moqui.basic.Enumeration enumCode="template_client_checkoutItemMessages" description="Template Client Checkout Item Messages" enumId="PsstTemplateClientCheckoutItemMessages" enumTypeId="ProductStoreSettingType"/>
+    <moqui.basic.Enumeration enumCode="template_client_checkoutMessages" description="Template Client Checkout Messages" enumId="PsstTemplateClientCheckoutMessages" enumTypeId="ProductStoreSettingType"/>
 
 
      <!-- server template setting types these should be moved ot mantle-udm ...-->
@@ -55,5 +55,4 @@ along with this software (see the LICENSE.md file). If not, see
     <!-- store setting used for dynamically setting the productStoreId depending on the hostname -->
     <moqui.basic.Enumeration enumCode="product_store_id_from_hostname" description="Product Store ID From Hostname" enumId="PsstHostname" enumTypeId="ProductStoreSettingType"/>
     <moqui.basic.Enumeration enumCode="show_prop_65_warning" description="Show the Prop 65 warning" enumId="PsstProp65Warning" enumTypeId="ProductStoreSettingType"/>
-    <moqui.basic.Enumeration enumCode="show_checkout_item_messages" description="Show messages for items in checkout page" enumId="PsstCheckoutItemMessages" enumTypeId="ProductStoreSettingType"/>
 </entity-facade-xml>

--- a/data/PopRestStoreAaaSetupData.xml
+++ b/data/PopRestStoreAaaSetupData.xml
@@ -38,6 +38,7 @@ along with this software (see the LICENSE.md file). If not, see
     <moqui.basic.Enumeration enumCode="template_client_orderHistory" description="Template Client Order History" enumId="PsstTemplateClientOrderHistory" enumTypeId="ProductStoreSettingType"/>
     <moqui.basic.Enumeration enumCode="template_client_productImage" description="Template Client Product Image" enumId="PsstTemplateClientProductImage" enumTypeId="ProductStoreSettingType"/>
     <moqui.basic.Enumeration enumCode="template_client_resetPassword" description="Template Client Reset Password" enumId="PsstTemplateClientResetPassword" enumTypeId="ProductStoreSettingType"/>
+    <moqui.basic.Enumeration enumCode="template_client_checkoutItemMessages" description="Template Client Checkout Item Messages" enumId="PsstTemplateClientCheckoutItemMessages" enumTypeId="ProductStoreSettingType"/>
 
 
      <!-- server template setting types these should be moved ot mantle-udm ...-->
@@ -54,4 +55,5 @@ along with this software (see the LICENSE.md file). If not, see
     <!-- store setting used for dynamically setting the productStoreId depending on the hostname -->
     <moqui.basic.Enumeration enumCode="product_store_id_from_hostname" description="Product Store ID From Hostname" enumId="PsstHostname" enumTypeId="ProductStoreSettingType"/>
     <moqui.basic.Enumeration enumCode="show_prop_65_warning" description="Show the Prop 65 warning" enumId="PsstProp65Warning" enumTypeId="ProductStoreSettingType"/>
+    <moqui.basic.Enumeration enumCode="show_checkout_item_messages" description="Show messages for items in checkout page" enumId="PsstCheckoutItemMessages" enumTypeId="ProductStoreSettingType"/>
 </entity-facade-xml>

--- a/screen/store/components/ComponentsCheckout.js
+++ b/screen/store/components/ComponentsCheckout.js
@@ -56,7 +56,7 @@ storeComps.CheckOutPage = {
     extends: storeComps.CheckoutNavbar,
     data: function() { return {
             cvv: "", showCvvError: false, homePath: "", storePath: "", customerInfo: {}, productsInCart: {}, shippingAddress: {}, shippingAddressSelect: {}, paymentMethod: {}, shippingMethod: {}, showProp65: "false",
-            billingAddress: {}, billingAddressOption: "", listShippingAddress: [], listPaymentMethods: [],  promoCode: "", promoError: "", postalAddressStateGeoSelected: null,
+            showItemMessages:"false", billingAddress: {}, billingAddressOption: "", listShippingAddress: [], listPaymentMethods: [],  promoCode: "", promoError: "", postalAddressStateGeoSelected: null,
             countriesList: [], regionsList: [], shippingOption: "", addressOption: "", paymentOption: "", isSameAddress: "0", shippingItemPrice: 0,
             isUpdate: false, isSpinner: false, responseMessage: "", toNameErrorMessage: "", countryErrorMessage: "", addressErrorMessage: "", 
             cityErrorMessage: "", stateErrorMessage: "", postalCodeErrorMessage: "", contactNumberErrorMessage: "", paymentId: 0, 
@@ -421,6 +421,7 @@ storeComps.CheckOutPage = {
     },
     components: { "product-image": storeComps.ProductImageTemplate },
     mounted: function() {
+        console.log(storeConfig)
         this.loading = true;
         if (this.$root.apiKey == null) {
             localStorage.redirect = 'checkout';
@@ -429,6 +430,7 @@ storeComps.CheckOutPage = {
             this.homePath = storeConfig.homePath;
             this.storePath = storeConfig.storePath;
             this.showProp65 = storeConfig.show_prop_65_warning;
+            this.showItemMessages = storeConfig.show_checkout_item_messages;
             this.getCustomerInfo();
             this.getCartShippingOptions();
             this.getCustomerShippingAddresses();
@@ -472,6 +474,12 @@ storeComps.SuccessCheckOut = {
         this.getCustomerOrderById();
     }
 };
+
+storeComps.CheckoutItemMessages = {
+    name: "checkout-item-messages",
+    props: { itemList: Array }
+};
+
 storeComps.SuccessCheckOutTemplate = getPlaceholderRoute("template_client_checkoutSuccess", "SuccessCheckOut");
 
 storeComps.CheckoutContactInfoTemplate = getPlaceholderRoute("template_client_contactInfo", "contactInfo");
@@ -479,6 +487,9 @@ Vue.component("contact-info", storeComps.CheckoutContactInfoTemplate);
 
 storeComps.CheckoutProp65Template = getPlaceholderRoute("template_client_prop65", "prop65Warning");
 Vue.component("prop65-warning", storeComps.CheckoutProp65Template);
+
+storeComps.CheckoutItemMessagesTemplate = getPlaceholderRoute("template_client_checkoutItemMessages", "CheckoutItemMessages", storeComps.CheckoutItemMessages.props);
+Vue.component("checkout-item-messages", storeComps.CheckoutItemMessagesTemplate);
 
 storeComps.CheckoutNavbarTemplate = getPlaceholderRoute("template_client_checkoutHeader", "CheckoutNavbar", storeComps.CheckoutNavbar.props);
 Vue.component("checkout-navbar", storeComps.CheckoutNavbarTemplate);

--- a/screen/store/components/ComponentsCheckout.js
+++ b/screen/store/components/ComponentsCheckout.js
@@ -56,7 +56,7 @@ storeComps.CheckOutPage = {
     extends: storeComps.CheckoutNavbar,
     data: function() { return {
             cvv: "", showCvvError: false, homePath: "", storePath: "", customerInfo: {}, productsInCart: {}, shippingAddress: {}, shippingAddressSelect: {}, paymentMethod: {}, shippingMethod: {}, showProp65: "false",
-            showItemMessages:"false", billingAddress: {}, billingAddressOption: "", listShippingAddress: [], listPaymentMethods: [],  promoCode: "", promoError: "", postalAddressStateGeoSelected: null,
+            showCheckoutMessages:false, billingAddress: {}, billingAddressOption: "", listShippingAddress: [], listPaymentMethods: [],  promoCode: "", promoError: "", postalAddressStateGeoSelected: null,
             countriesList: [], regionsList: [], shippingOption: "", addressOption: "", paymentOption: "", isSameAddress: "0", shippingItemPrice: 0,
             isUpdate: false, isSpinner: false, responseMessage: "", toNameErrorMessage: "", countryErrorMessage: "", addressErrorMessage: "", 
             cityErrorMessage: "", stateErrorMessage: "", postalCodeErrorMessage: "", contactNumberErrorMessage: "", paymentId: 0, 
@@ -429,7 +429,7 @@ storeComps.CheckOutPage = {
             this.homePath = storeConfig.homePath;
             this.storePath = storeConfig.storePath;
             this.showProp65 = storeConfig.show_prop_65_warning;
-            this.showItemMessages = storeConfig.show_checkout_item_messages;
+            this.showCheckoutMessages = storeConfig.template_client_checkoutMessages ? true : false;
             this.getCustomerInfo();
             this.getCartShippingOptions();
             this.getCustomerShippingAddresses();

--- a/screen/store/components/ComponentsCheckout.js
+++ b/screen/store/components/ComponentsCheckout.js
@@ -421,7 +421,6 @@ storeComps.CheckOutPage = {
     },
     components: { "product-image": storeComps.ProductImageTemplate },
     mounted: function() {
-        console.log(storeConfig)
         this.loading = true;
         if (this.$root.apiKey == null) {
             localStorage.redirect = 'checkout';
@@ -475,8 +474,8 @@ storeComps.SuccessCheckOut = {
     }
 };
 
-storeComps.CheckoutItemMessages = {
-    name: "checkout-item-messages",
+storeComps.CheckoutMessages = {
+    name: "checkout-messages",
     props: { itemList: Array }
 };
 
@@ -488,8 +487,8 @@ Vue.component("contact-info", storeComps.CheckoutContactInfoTemplate);
 storeComps.CheckoutProp65Template = getPlaceholderRoute("template_client_prop65", "prop65Warning");
 Vue.component("prop65-warning", storeComps.CheckoutProp65Template);
 
-storeComps.CheckoutItemMessagesTemplate = getPlaceholderRoute("template_client_checkoutItemMessages", "CheckoutItemMessages", storeComps.CheckoutItemMessages.props);
-Vue.component("checkout-item-messages", storeComps.CheckoutItemMessagesTemplate);
+storeComps.CheckoutMessagesTemplate = getPlaceholderRoute("template_client_checkoutMessages", "CheckoutMessages", storeComps.CheckoutMessages.props);
+Vue.component("checkout-messages", storeComps.CheckoutMessagesTemplate);
 
 storeComps.CheckoutNavbarTemplate = getPlaceholderRoute("template_client_checkoutHeader", "CheckoutNavbar", storeComps.CheckoutNavbar.props);
 Vue.component("checkout-navbar", storeComps.CheckoutNavbarTemplate);

--- a/screen/store/components/template/CheckoutPage.html
+++ b/screen/store/components/template/CheckoutPage.html
@@ -48,8 +48,9 @@
                 </div>
 
                 <!-- Optional Item Messages -->
-                <checkout-messages :item-list="productsInCart.orderItemList"/>
-
+                <template v-if="showCheckoutMessages">
+                    <checkout-messages :item-list="productsInCart.orderItemList" />
+                </template>
                 <hr>
                 <div class="row div-total">
                     <span class="col col-9 col-lg-9">Products</span>

--- a/screen/store/components/template/CheckoutPage.html
+++ b/screen/store/components/template/CheckoutPage.html
@@ -47,6 +47,11 @@
                     </div>
                 </div>
 
+                <!-- Optional Item Messages -->
+                <div v-if="showItemMessages == 'true' && productsInCart.orderItemList">
+                    <checkout-item-messages :item-list="productsInCart.orderItemList"/>
+                </div>
+
                 <hr>
                 <div class="row div-total">
                     <span class="col col-9 col-lg-9">Products</span>

--- a/screen/store/components/template/CheckoutPage.html
+++ b/screen/store/components/template/CheckoutPage.html
@@ -48,9 +48,7 @@
                 </div>
 
                 <!-- Optional Item Messages -->
-                <div v-if="showItemMessages == 'true' && productsInCart.orderItemList">
-                    <checkout-item-messages :item-list="productsInCart.orderItemList"/>
-                </div>
+                <checkout-messages :item-list="productsInCart.orderItemList"/>
 
                 <hr>
                 <div class="row div-total">

--- a/screen/store/d.xml
+++ b/screen/store/d.xml
@@ -63,8 +63,7 @@ along with this software (see the LICENSE.md file). If not, see
             template_client_contactInfo: "/store/components/template/contactInfo.html",
             template_client_prop65: "/store/components/template/prop65Warning.html",
             show_prop_65_warning: "false",
-            template_client_checkoutItemMessages: "/store/components/template/CheckoutItemMessages.html",
-            show_checkout_item_messages: "false",
+            template_client_checkoutMessages: ""
         };
     </script>
         """

--- a/screen/store/d.xml
+++ b/screen/store/d.xml
@@ -63,6 +63,8 @@ along with this software (see the LICENSE.md file). If not, see
             template_client_contactInfo: "/store/components/template/contactInfo.html",
             template_client_prop65: "/store/components/template/prop65Warning.html",
             show_prop_65_warning: "false",
+            template_client_checkoutItemMessages: "/store/components/template/CheckoutItemMessages.html",
+            show_checkout_item_messages: "false",
         };
     </script>
         """


### PR DESCRIPTION
We have created a little component in the checkout page where the stores can add custom messages. The component receives the order item list as optional prop. To complete this feature we did this:

-Added a store setting for checkout messages template.
-Register the new component in the Vue instance.
-Added new component to the checkout page template.

Also the component is only shown if the new store setting for checkout messages template exist.