### PR TITLE
ProductService.xml now returns idCode of features, correct product availability and productFeatureId

### DIFF
--- a/service/popstore/ProductServices.xml
+++ b/service/popstore/ProductServices.xml
@@ -160,7 +160,7 @@ along with this software (see the LICENSE.md file). If not, see
             <set field="productAvailability" from="[:]"/>
             <iterate list="productAssetSumList" entry="assetSum">
                 <script>
-                    productAvailability.put(assetSum.productId, assetSum.availableToPromiseTotal>0)
+                    productAvailability.put(assetSum.productId, assetSum.availableToPromiseTotal)
                 </script>
             </iterate>
         </actions>
@@ -391,7 +391,7 @@ along with this software (see the LICENSE.md file). If not, see
                     <entity-find-one entity-name="mantle.product.feature.ProductFeature" value-field="productFeature" cache="true">
                         <field-map field-name="productFeatureId" from="variantProductAssoc.productFeatureId"/>
                     </entity-find-one>
-                    <service-call name="popstore.ProductServices.get#ProductQuantity" out-map="productQuantity" in-map="[productId:variantProductAssoc.toProductId]"/>
+                    <service-call name="popstore.ProductServices.get#ProductQuantity" out-map="productQuantity" in-map="[productId:variantProductAssoc.toProductId]"  out-map-add-to-existing="false" />
                     <entity-find-one entity-name="moqui.basic.Enumeration" value-field="featureType" cache="true">
                         <field-map field-name="enumId" from="productFeature.productFeatureTypeEnumId"/>
                     </entity-find-one>
@@ -416,7 +416,7 @@ along with this software (see the LICENSE.md file). If not, see
                         if (!featureSet) {
                             listFeatures.put(content, 
                             [[productFeatureId:productFeature.productFeatureId, 
-                            productFeatureTypeEnumId:productFeature.productFeatureTypeEnumId, 
+                            productFeatureTypeEnumId:productFeature.productFeatureTypeEnumId, idCode:productFeature.idCode,
                             description:productFeature.description, abbrev:productFeature.abbrev, price:selectedPrices]])
                         } else {
                             boolean isItemInList = false
@@ -428,17 +428,17 @@ along with this software (see the LICENSE.md file). If not, see
                             }
                             if(!isItemInList) {
                                 featureSet.add([productFeatureId:productFeature.productFeatureId, 
-                                productFeatureTypeEnumId:productFeature.productFeatureTypeEnumId, 
+                                productFeatureTypeEnumId:productFeature.productFeatureTypeEnumId, idCode:productFeature.idCode,
                                 description:productFeature.description, abbrev:productFeature.abbrev, price:selectedPrices])
                             }
                         }
 
                         def optionSet = variantOptions.get(item)
                         if (!optionSet) {
-                            variantOptions.put(item, [[productId: variantProductAssoc.toProductId, description:productFeature.description, quantity: productQuantity.productQuantity,
+                            variantOptions.put(item, [[productId: variantProductAssoc.toProductId, description:productFeature.description, quantity: productQuantity.productQuantity, productFeatureId:productFeature.productFeatureId, 
                             prices:selectedPrices, contentList:productContentList]])
                         } else {
-                            optionSet.add([productId: variantProductAssoc.toProductId, description:productFeature.description, quantity: productQuantity.productQuantity,
+                            optionSet.add([productId: variantProductAssoc.toProductId, description:productFeature.description, quantity: productQuantity.productQuantity, productFeatureId:productFeature.productFeatureId, 
                             prices:selectedPrices, contentList:productContentList])
                         }
                         priceSet = null


### PR DESCRIPTION
This modifies the product services to return a bit more data.

- productAvailability now returns the quantity available for each variant instead of just a boolean. In addition, there was a bug where quantity from one variant was affecting others. This was resolved with out-map-add-to-existing="false"
- The variants now also return the idCode for the product feature. This helps when the ID code can be used for such things as HEX num on a color. 
- The Product Features now also return the productFeatureId where previously only 'description' was returned. Front end UI would be better served with an Id for elements such as combo boxes and radio buttons to choose between features.  