### PR TITLE
Added service to return content

### DIFF
--- a/service/popstore/ProductServices.xml
+++ b/service/popstore/ProductServices.xml
@@ -105,6 +105,18 @@ along with this software (see the LICENSE.md file). If not, see
         </actions>
     </service>
 
+    <service verb="get" noun="LocationText">
+        <in-parameters>
+            <parameter name="location" required="true"/>
+        </in-parameters>
+        <out-parameters>
+            <parameter name="text"/>
+        </out-parameters>
+        <actions>
+            <set field="text" from="ec.resource.getLocationText(location, true)"/>
+        </actions>
+    </service>
+
     <!-- TODO: this service is not adequately constrained, will get inventory from all facilities, owners, pools, etc; see AssetServices.get#AvailableInventory -->
     <service verb="get" noun="ProductQuantity">
         <in-parameters>


### PR DESCRIPTION
This service was useful for displaying product content in the front end. Currently, the ProductContent list does not return the actual content text. I added this service to return that text:
```
<#assign ingredients = ec.service.sync().name("popstore.ProductServices.get#LocationText")
+        .parameter("location", ingredientsContent.contentLocation).call().text>
```

Another solution might be to return a map of productContentText on the context, so looking for feedback on this.