### PR TITLE
Added a service to get associated products

### DIFF
--- a/service/popstore/ProductServices.xml
+++ b/service/popstore/ProductServices.xml
@@ -105,6 +105,48 @@ along with this software (see the LICENSE.md file). If not, see
         </actions>
     </service>
 
+    <service verb="get" noun="LocationText">
+        <in-parameters>
+            <parameter name="location" required="true"/>
+        </in-parameters>
+        <out-parameters>
+            <parameter name="text"/>
+        </out-parameters>
+        <actions>
+            <set field="text" from="ec.resource.getLocationText(location, true)"/>
+        </actions>
+    </service>
+
+    <!-- Service to get associated products for such thigns as upsells. -->
+    <service verb="get" noun="ProductAssocAndDetails">
+        <in-parameters>
+            <parameter name="productId" />
+            <parameter name="assocType" default="PatVariant" />
+            <parameter name="productStoreId"/>
+        </in-parameters>
+        <out-parameters>
+            <parameter name="products" type="List" />
+        </out-parameters>
+        <actions>
+            <entity-find entity-name="ProductAssocAndTo" list="assocs">
+                <search-form-inputs default-order-by="sequenceNum"/>
+                <econdition field-name="productAssocTypeEnumId" from="assocType"/>
+                <econdition field-name="productId"/><date-filter/>
+            </entity-find>
+
+            <set field="products" from="[]"/>
+            <iterate list="assocs" entry="assoc">
+                <service-call name="mantle.product.PriceServices.get#ProductPrice" out-map="prices"
+                            in-map="context + [productId:assoc.toProductId]" />
+
+                <service-call name="popstore.ProductServices.find#ProductContentList" out-map="content" 
+                        in-map="[productId:assoc.toProductId]"/>
+
+                <script>products.add(['product':assoc, 'prices':prices, 'content':content.productContentList ])</script>
+            </iterate>
+        </actions>
+    </service>
+
     <!-- TODO: this service is not adequately constrained, will get inventory from all facilities, owners, pools, etc; see AssetServices.get#AvailableInventory -->
     <service verb="get" noun="ProductQuantity">
         <in-parameters>


### PR DESCRIPTION
Currently, the only services to get Associated products are calling entities that depend on Features, e.g mantle.product.ProductAssocAndToFeatureAppl

We wanted to display upsell products, so we implemented this generic service to get associated products and their content. 