### PR TITLE
Made checkout root customizable

### DIFF
--- a/data/PopRestStoreAaaSetupData.xml
+++ b/data/PopRestStoreAaaSetupData.xml
@@ -50,6 +50,7 @@ along with this software (see the LICENSE.md file). If not, see
     <moqui.basic.Enumeration enumCode="template_server_product" description="Template Server Product" enumId="PsstTemplateServerProduct" enumTypeId="ProductStoreSettingType"/>
     <moqui.basic.Enumeration enumCode="template_server_search" description="Template Server Search" enumId="PsstTemplateServerSearch" enumTypeId="ProductStoreSettingType"/>
     <moqui.basic.Enumeration enumCode="template_server_category" description="Template Server Category" enumId="PsstTemplateServerCategory" enumTypeId="ProductStoreSettingType"/>
+    <moqui.basic.Enumeration enumCode="template_server_checkout" description="Template Server Checkout" enumId="PsstTemplateServerCheckout" enumTypeId="ProductStoreSettingType"/>
 
     <!-- store setting used for dynamically setting the productStoreId depending on the hostname -->
     <moqui.basic.Enumeration enumCode="product_store_id_from_hostname" description="Product Store ID From Hostname" enumId="PsstHostname" enumTypeId="ProductStoreSettingType"/>

--- a/screen/store.xml
+++ b/screen/store.xml
@@ -92,6 +92,7 @@ var storeInfo = ${storeInfoJson};
         <set field="template_server_product" from="storeInfo.settings.template_server_product" default-value="component://PopRestStore/template/store/product.html.ftl"/>
         <set field="template_server_content" from="storeInfo.settings.template_server_content" default-value="component://PopRestStore/template/store/help.html.ftl"/>
         <set field="template_server_search" from="storeInfo.settings.template_server_search" default-value="component://PopRestStore/template/store/search.html.ftl"/>
+        <set field="template_server_checkout" from="storeInfo.settings.template_server_checkout" default-value="component://PopRestStore/template/store/checkout.html.ftl"/>
     </pre-actions>
 
     <widgets>

--- a/screen/store/d.xml
+++ b/screen/store/d.xml
@@ -111,7 +111,6 @@ along with this software (see the LICENSE.md file). If not, see
     ]]></script></pre-actions>
 
     <widgets>
-        <render-mode><text type="html"><![CDATA[<div id="app"></div>]]></text></render-mode>
-        <!-- TODO use server rendered footer to avoid redundant templates: <render-mode><text type="html" location="component://PopRestStore/template/store/footer.html.ftl"/></render-mode> -->
+        <render-mode><text type="html" location="${template_server_checkout}"/></render-mode>
     </widgets>
 </screen>

--- a/template/store/checkout.html.ftl
+++ b/template/store/checkout.html.ftl
@@ -1,0 +1,1 @@
+<div id="app"></div>


### PR DESCRIPTION
Previously, there was no way to add HTML/CSS/JS specific to the checkout screens. Here users can add their own freemarker template and add server-side headers or footers, etc. 