### PR TITLE
changed server rendered root d# to d to allow google analytics to function for server rendered screens

### DIFF
--- a/screen/store/components/template/CheckoutSuccess.html
+++ b/screen/store/components/template/CheckoutSuccess.html
@@ -59,7 +59,7 @@
                 <hr class="hr-title">
                 <div class="row mb-2">
                     <span class="col text-blight">ORDER NUMBER: </span>
-                    <a class="col order-link-text" :href="'/store/d#/orders/'+orderList.orderHeader.orderId">
+                    <a class="col order-link-text" :href="'/store/d/orders/'+orderList.orderHeader.orderId">
                         {{orderList.orderHeader.orderId}}
                     </a>
                 </div>

--- a/template/store/navbar.html.ftl
+++ b/template/store/navbar.html.ftl
@@ -80,8 +80,8 @@
                             ${partyDetail.firstName} ${partyDetail.lastName} ${partyDetail.organizationName!} <i class="fas fa-angle-down icon-down"></i>
                         </a>
                         <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-                            <a class="dropdown-item item-color" href="/store/d#/account">Account Settings</a>
-                            <a class="dropdown-item item-color" href="/store/d#/orders">My Orders</a>
+                            <a class="dropdown-item item-color" href="/store/d/account">Account Settings</a>
+                            <a class="dropdown-item item-color" href="/store/d/orders">My Orders</a>
                             <div role="separator" class="dropdown-divider"></div>
                             <form method="get" action="/store/logOut">
                                 <button type="submit" class="dropdown-item item-color">Signout</button>
@@ -90,10 +90,10 @@
                     </li>
                 <#else>
                     <li class="nav-item">
-                        <a href="/store/d#/account/create" class="nav-link">Join Now</a>
+                        <a href="/store/d/account/create" class="nav-link">Join Now</a>
                     </li>
                     <li class="nav-item">
-                        <a href="/store/d#/login" class="nav-link"><i class="fas fa-user"></i> Sign In</a>
+                        <a href="/store/d/login" class="nav-link"><i class="fas fa-user"></i> Sign In</a>
                     </li>
                 </#if>
 
@@ -107,7 +107,7 @@
                     </#if>
                 <li class="nav-item">
                     <#if cartCount gt 0>
-                        <a class="nav-link" href="/store/d#/checkout">
+                        <a class="nav-link" href="/store/d/checkout">
                     <#else>
                         <a class="nav-link pointer" data-toggle="modal" data-target="#emptyCartModal">
                     </#if>

--- a/template/store/product.html.ftl
+++ b/template/store/product.html.ftl
@@ -13,7 +13,7 @@
     <#if addedCorrect?? && addedCorrect == 'true'>
         <div class="alert alert-primary mt-3 mb-3" role="alert">
             <i class="far fa-check-square"></i> You added a ${product.productName} to your shopping cart.
-            <a class="float-right" href="/store/d#/checkout">Go to Checkout <i class="fas fa-arrow-right"></i></a>
+            <a class="float-right" href="/store/d/checkout">Go to Checkout <i class="fas fa-arrow-right"></i></a>
         </div>
     </#if>
     <#--  <div class="row d-flex justify-content-center">


### PR DESCRIPTION
Problem: 
I was notified that some implementations of google analytics didn't work for the server rendered screens (specifically the checkout screen). 

Possible Causes:
1. A theory as to why this is is because of the # in the d screen
2.  Google Analytics doesn't allow for url fragments (# symbols in the url) in their tracking url by default, see [here](https://webmasters.stackexchange.com/questions/104241/can-google-analytics-track-url-fragment-in-url)

Possible Solutions:
1. This PR request will test to see if google analytics will still work for the checkouts screen despite vue-router adding 
2. Change google analytics settings to allow for segmented urls (see [here](https://www.simoahava.com/gtm-tips/track-url-fragments-as-pageviews/))
3. Change vue-router configuration to allow for not having segments (not sure how to do this, but might not be necessary)

Explanation:
I tried removing the # when trying to render using the vue-router and it made it so that the url is not https://.../d#/checkout/ but instead https://.../d/checkout#/. I didn't notice any functionality changes, and don't imagine that there would be functionality related to having a # in the url, but to test whether this is the problem. This would be a good way to test if this is the correct problem for getting google analytics to work. 

Possible Drawbacks:
The url for server rendered screens is changed from https://.../d#/checkout/ to https://.../d/checkout#/. This shouldn't change functionality, but it might.