### PR TITLE
remove invalid indexation

### DIFF
--- a/data/PopRestStoreProductData.xml
+++ b/data/PopRestStoreProductData.xml
@@ -393,5 +393,4 @@ along with this software (see the LICENSE.md file). If not, see
 
     <!-- run index for search -->
     <org.moqui.search.SearchServices.indexDataFeedDocuments dataFeedId="MantleSearch"/>
-    <org.moqui.search.SearchServices.indexDataFeedDocuments dataFeedId="PopCommerceSearch"/>
 </entity-facade-xml>


### PR DESCRIPTION
PopRestStore does not depend on PopCommerce, and hence should not call the indexation service on PopCommerce based index